### PR TITLE
Use singleton key to avoid azure rate limits

### DIFF
--- a/Rusty.Jwt.Azure.Tests/AzureEndToEndTests.cs
+++ b/Rusty.Jwt.Azure.Tests/AzureEndToEndTests.cs
@@ -45,7 +45,7 @@ public class AzureEndToEndTests : IAsyncLifetime
         _jwt.Should().NotBeNull();
         _jwt.Id.Should().NotBeNullOrWhiteSpace();
         _jwt.Token.Should().NotBeNullOrWhiteSpace();
-        _jwt.ExpiresIn.Should().BeCloseTo(SecondsTtl, 1);
+        _jwt.ExpiresIn.Should().BeCloseTo(SecondsTtl, 3);
     }
 
     [Fact]

--- a/Rusty.Jwt.Azure/Extensions/JwtServiceBuilderExtensions.cs
+++ b/Rusty.Jwt.Azure/Extensions/JwtServiceBuilderExtensions.cs
@@ -15,7 +15,7 @@ public static class JwtServiceBuilderExtensions
         HashAlgorithm hashAlgorithm = HashAlgorithm.SHA256,
         SigningKeyMode mode = SigningKeyMode.SignAndVerify)
     {
-        builder.Services.AddTransient(_ =>
+        builder.Services.AddSingleton(_ =>
         {
             var credential = credentials ?? new DefaultAzureCredential();
 

--- a/Rusty.Jwt.Azure/Rusty.Jwt.Azure.csproj
+++ b/Rusty.Jwt.Azure/Rusty.Jwt.Azure.csproj
@@ -13,6 +13,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>azure,key vault,jwt</PackageTags>
         <LangVersion>10</LangVersion>
+        <Version>1.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the service lifetime of the `AzureSigningKey` to singleton, as we can hit Azure rate limits on initalization if it's transient.